### PR TITLE
CATL-1791: Add letterheads list page

### DIFF
--- a/CRM/ManageLetterheads/Page/LetterheadsListPage.php
+++ b/CRM/ManageLetterheads/Page/LetterheadsListPage.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * LetterheadsListPage class.
+ *
+ * A page that displays the full list of letterheads.
+ */
+class CRM_ManageLetterheads_Page_LetterheadsListPage extends CRM_Core_Page {
+
+  /**
+   * @var array
+   *   List of "Available For" labels, indexed by value.
+   */
+  private $availableForLabels;
+
+  /**
+   * Assigns the page's template values.
+   */
+  public function run() {
+    $this->loadAvailableForLabels();
+    $this->assign('letterheads', $this->getLetterheads());
+
+    parent::run();
+  }
+
+  /**
+   * Loads the "Available For" labels, indexed by values.
+   */
+  private function loadAvailableForLabels() {
+    $this->availableForLabels = [];
+    $availableFor = civicrm_api3('OptionValue', 'get', [
+      'sequential' => 0,
+      'option_group_id' => 'manageletterheads_available_for',
+      'options' => [
+        'limit' => 0,
+      ],
+    ]);
+
+    foreach ($availableFor['values'] as $availableFor) {
+      $this->availableForLabels[$availableFor['value']] = $availableFor['label'];
+    };
+  }
+
+  /**
+   * Returns the full list of letterheads.
+   *
+   * The letterheads fields are formatted so they include values as rendered on
+   * the template.
+   *
+   * @return array
+   */
+  private function getLetterheads() {
+    $letterheads = civicrm_api3('Letterhead', 'get', [
+      'sequential' => 1,
+      'options' => [
+        'limit' => 0,
+        'sort' => 'weight ASC',
+      ],
+    ]);
+
+    return array_map(
+      [$this, 'getLetterheadViewValues'],
+      $letterheads['values']
+    );
+  }
+
+  /**
+   * Returns the formatted values for a given letterhead.
+   *
+   * It returns the available for labels instead of their values as well as
+   * "Yes" or "No" for the active field instead of using numerical values.
+   *
+   * @param array $letterhead
+   *   The letterhead data as returned by the API.
+   * @return array
+   *   The formatted letterhead.
+   */
+  private function getLetterheadViewValues(array $letterhead) {
+    $availableForLabels = $this->getAvailableForLabelsFromValues(
+      $letterhead['available_for']
+    );
+
+    return [
+      'id' => $letterhead['id'],
+      'title' => $letterhead['title'],
+      'description' => $letterhead['description'],
+      'available_for' => implode($availableForLabels, ', '),
+      'weight' => $letterhead['weight'],
+      'is_active' => $letterhead['is_active'] === '1' ? ts('Yes') : ts('No'),
+    ];
+  }
+
+  /**
+   * Returns the labels for the given Available For values.
+   *
+   * @param array $optionValues
+   *   A list of Available For values.
+   * @return array
+   *   A list of Available For labels.
+   */
+  private function getAvailableForLabelsFromValues(array $optionValues) {
+    return array_map(
+      function ($optionValue) {
+        return $this->availableForLabels[$optionValue];
+      },
+      $optionValues
+    );
+  }
+
+}

--- a/CRM/ManageLetterheads/Page/LetterheadsListPage.php
+++ b/CRM/ManageLetterheads/Page/LetterheadsListPage.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_ManageLetterheads_BAO_LetterheadAvailability as LetterheadAvailability;
+
 /**
  * LetterheadsListPage class.
  *
@@ -17,28 +19,11 @@ class CRM_ManageLetterheads_Page_LetterheadsListPage extends CRM_Core_Page {
    * Assigns the page's template values.
    */
   public function run() {
-    $this->loadAvailableForLabels();
+    $this->availableForLabels = LetterheadAvailability::buildOptions('available_for');
+
     $this->assign('letterheads', $this->getLetterheads());
 
     parent::run();
-  }
-
-  /**
-   * Loads the "Available For" labels, indexed by values.
-   */
-  private function loadAvailableForLabels() {
-    $this->availableForLabels = [];
-    $availableFor = civicrm_api3('OptionValue', 'get', [
-      'sequential' => 0,
-      'option_group_id' => 'manageletterheads_available_for',
-      'options' => [
-        'limit' => 0,
-      ],
-    ]);
-
-    foreach ($availableFor['values'] as $availableFor) {
-      $this->availableForLabels[$availableFor['value']] = $availableFor['label'];
-    };
   }
 
   /**

--- a/CRM/ManageLetterheads/Page/LetterheadsListPage.php
+++ b/CRM/ManageLetterheads/Page/LetterheadsListPage.php
@@ -20,10 +20,28 @@ class CRM_ManageLetterheads_Page_LetterheadsListPage extends CRM_Core_Page {
    */
   public function run() {
     $this->availableForLabels = LetterheadAvailability::buildOptions('available_for');
+    $pager = $this->getPager();
+    list($offset, $limit) = $pager->getOffsetAndRowCount();
 
-    $this->assign('letterheads', $this->getLetterheads());
+    $this->assign_by_ref('pager', $pager);
+    $this->assign('letterheads', $this->getLetterheads($offset, $limit));
 
     parent::run();
+  }
+
+  /**
+   * Returns the pager object that can be used to paginate letterheads.
+   *
+   * @return CRM_Utils_Pager
+   */
+  private function getPager() {
+    $totalLetterheads = civicrm_api3('Letterhead', 'getcount', []);
+    $params['total'] = $totalLetterheads;
+    $params['currentPage'] = $this->get(CRM_Utils_Pager::PAGE_ID);
+    $params['rowCount'] = CRM_Utils_Pager::ROWCOUNT;
+    $pager = new CRM_Utils_Pager($params);
+
+    return $pager;
   }
 
   /**
@@ -32,13 +50,18 @@ class CRM_ManageLetterheads_Page_LetterheadsListPage extends CRM_Core_Page {
    * The letterheads fields are formatted so they include values as rendered on
    * the template.
    *
+   * @param $offset
+   *   The offset record to start fetching letterheads from.
+   * @param $limit
+   *   The limit of letterheads to return.
    * @return array
    */
-  private function getLetterheads() {
+  private function getLetterheads($offset, $limit) {
     $letterheads = civicrm_api3('Letterhead', 'get', [
       'sequential' => 1,
       'options' => [
-        'limit' => 0,
+        'limit' => $limit,
+        'offset' => $offset,
         'sort' => 'weight ASC',
       ],
     ]);

--- a/CRM/ManageLetterheads/Page/LetterheadsListPage.php
+++ b/CRM/ManageLetterheads/Page/LetterheadsListPage.php
@@ -35,7 +35,7 @@ class CRM_ManageLetterheads_Page_LetterheadsListPage extends CRM_Core_Page {
    * @return CRM_Utils_Pager
    */
   private function getPager() {
-    $totalLetterheads = civicrm_api3('Letterhead', 'getcount', []);
+    $totalLetterheads = civicrm_api3('Letterhead', 'getcount');
     $params['total'] = $totalLetterheads;
     $params['currentPage'] = $this->get(CRM_Utils_Pager::PAGE_ID);
     $params['rowCount'] = CRM_Utils_Pager::ROWCOUNT;

--- a/templates/CRM/ManageLetterheads/Page/LetterheadsListPage.tpl
+++ b/templates/CRM/ManageLetterheads/Page/LetterheadsListPage.tpl
@@ -1,43 +1,46 @@
-<div id="bootstrap-theme" class="crm-container">
-  <div class="panel panel-default">
-    <div class="panel-body">
-      <div class="text-right">
-        <button class="btn btn-large btn-primary">
-          <i class="fa fa-plus-circle"></i>
-          Create new letterhead
-        </button>
+<div class="crm-container">
+  <div id="bootstrap-theme">
+    <div class="panel panel-default">
+      <div class="panel-body">
+        <div class="text-right">
+          <button class="btn btn-large btn-primary">
+            <i class="fa fa-plus-circle"></i>
+            Create new letterhead
+          </button>
+        </div>
+        {if !count($letterheads)}
+          <div class="crm-case-custom-form-block-empty text-center clearfix">
+            No Letterheads are available.
+          <div>
+        {/if}
       </div>
-      {if !count($letterheads)}
-        <div class="crm-case-custom-form-block-empty text-center clearfix">
-          No Letterheads are available.
-        <div>
+      {if count($letterheads)}
+        <table class="table table-responsive table-striped">
+          <thead>
+            <tr>
+              <th>Title</th>
+              <th>Description</th>
+              <th>Available for</th>
+              <th>Order</th>
+              <th>Enabled</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {foreach from=$letterheads item=letterhead}
+              <tr>
+                <td>{$letterhead.title}</td>
+                <td>{$letterhead.description}</td>
+                <td>{$letterhead.available_for}</td>
+                <td>{$letterhead.weight}</td>
+                <td>{$letterhead.is_active}</td>
+                <td></td>
+              </tr>
+            {/foreach}
+          </tbody>
+        </table>
       {/if}
     </div>
-    {if count($letterheads)}
-      <table class="table table-responsive table-striped">
-        <thead>
-          <tr>
-            <th>Title</th>
-            <th>Description</th>
-            <th>Available for</th>
-            <th>Order</th>
-            <th>Enabled</th>
-            <th>Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {foreach from=$letterheads item=letterhead}
-            <tr>
-              <td>{$letterhead.title}</td>
-              <td>{$letterhead.description}</td>
-              <td>{$letterhead.available_for}</td>
-              <td>{$letterhead.weight}</td>
-              <td>{$letterhead.is_active}</td>
-              <td></td>
-            </tr>
-          {/foreach}
-        </tbody>
-      </table>
-    {/if}
   </div>
+  {include file="CRM/common/pager.tpl" location="bottom"}
 </div>

--- a/templates/CRM/ManageLetterheads/Page/LetterheadsListPage.tpl
+++ b/templates/CRM/ManageLetterheads/Page/LetterheadsListPage.tpl
@@ -1,0 +1,43 @@
+<div id="bootstrap-theme" class="crm-container">
+  <div class="panel panel-default">
+    <div class="panel-body">
+      <div class="text-right">
+        <button class="btn btn-large btn-primary">
+          <i class="fa fa-plus-circle"></i>
+          Create new letterhead
+        </button>
+      </div>
+      {if !count($letterheads)}
+        <div class="crm-case-custom-form-block-empty text-center clearfix">
+          No Letterheads are available.
+        <div>
+      {/if}
+    </div>
+    {if count($letterheads)}
+      <table class="table table-responsive table-striped">
+        <thead>
+          <tr>
+            <th>Title</th>
+            <th>Description</th>
+            <th>Available for</th>
+            <th>Order</th>
+            <th>Enabled</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {foreach from=$letterheads item=letterhead}
+            <tr>
+              <td>{$letterhead.title}</td>
+              <td>{$letterhead.description}</td>
+              <td>{$letterhead.available_for}</td>
+              <td>{$letterhead.weight}</td>
+              <td>{$letterhead.is_active}</td>
+              <td></td>
+            </tr>
+          {/foreach}
+        </tbody>
+      </table>
+    {/if}
+  </div>
+</div>

--- a/xml/Menu/manageletterheads.xml
+++ b/xml/Menu/manageletterheads.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <menu>
   <item>
-    <path>civicrm/lettersheads/list</path>
+    <path>civicrm/letterheads/list</path>
     <page_callback>CRM_ManageLetterheads_Page_LetterheadsListPage</page_callback>
     <title>Letterheads List</title>
     <access_arguments>access CiviCRM</access_arguments>

--- a/xml/Menu/manageletterheads.xml
+++ b/xml/Menu/manageletterheads.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<menu>
+  <item>
+    <path>civicrm/lettersheads/list</path>
+    <page_callback>CRM_ManageLetterheads_Page_LetterheadsListPage</page_callback>
+    <title>Letterheads List</title>
+    <access_arguments>access CiviCRM</access_arguments>
+  </item>
+</menu>

--- a/xml/Menu/manageletterheads.xml
+++ b/xml/Menu/manageletterheads.xml
@@ -4,6 +4,6 @@
     <path>civicrm/letterheads/list</path>
     <page_callback>CRM_ManageLetterheads_Page_LetterheadsListPage</page_callback>
     <title>Letterheads List</title>
-    <access_arguments>access CiviCRM</access_arguments>
+    <access_arguments>manage letterheads</access_arguments>
   </item>
 </menu>


### PR DESCRIPTION
## Overview
This PR adds a page with the full list of letterheads.

## How it looks
![gif](https://user-images.githubusercontent.com/1642119/95513398-4901f780-0988-11eb-951c-f2a56933260a.gif)

## Technical Details

* The page was created using `civix generate:page`.
* The page class has a `getLetterheadViewValues` method that returns the letterhead fields as they should be displayed on the template instead of the raw values coming from the API. IE: the active field shows "Yes" or "No" instead of 1 or 0, and the available for field displays the labels for the option values instead of numbers.
* Some elements such as the "create new letterhead" button and the "actions" columns were added, but they have no behaviour related to them since they'll be done in future tickets.
* Pagination was done using the `CRM_Utils_Pager` class. This is generated in the `getPager` private function.
* The pagination template `CRM/common/pager.tpl` had to be included outside of the `#bootstrap-theme` class because it breaks in Shoreditch. This is something we probably need to fix globally, but for now the pagination looks usable.

## Notes

* Missing unit tests
