### PR TITLE
CATL: 1832:  Add Unit tests for the Letterhead Entity

### DIFF
--- a/CRM/ManageLetterheads/Test/Fabricator/Letterhead.php
+++ b/CRM/ManageLetterheads/Test/Fabricator/Letterhead.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * Fabricator class for Letterhead entity.
+ */
+class CRM_ManageLetterheads_Test_Fabricator_Letterhead {
+
+  /**
+   * Letterhead weight.
+   *
+   * @var int
+   */
+  private static $weight = 0;
+
+  /**
+   * Fabricate a letterhead entity.
+   *
+   * @param array $params
+   *   Parameters.
+   *
+   * @return mixed
+   */
+  public static function fabricate($params) {
+    $params = array_merge(self::getDefaultParams(), $params);
+    $result = civicrm_api3(
+      'Letterhead',
+      'create',
+      $params
+    );
+
+    self::$weight++;
+
+    return array_shift($result['values']);
+  }
+
+  /**
+   * Returns default letterhead parameters.
+   *
+   * @return array
+   *   Default letterhead parameters.
+   */
+  private static function getDefaultParams() {
+    return [
+      'description' => 'Letterhead description',
+      'weight' => self::$weight,
+      'is_active' => 1,
+      'content' => 'Letterhead content',
+    ];
+  }
+
+}

--- a/api/v3/Letterhead.php
+++ b/api/v3/Letterhead.php
@@ -27,7 +27,7 @@ function _civicrm_api3_letterhead_create_spec(&$spec) {
 function civicrm_api3_letterhead_create($params) {
   $extraFields = ['available_for'];
   foreach ($extraFields as $field) {
-    if (isset($params['field'])) {
+    if (isset($params[$field])) {
       $params[$field] = _civicrm_api3_letterhead_getParameterValue($params, $field);
     }
   }

--- a/tests/phpunit/BaseHeadlessTest.php
+++ b/tests/phpunit/BaseHeadlessTest.php
@@ -1,0 +1,14 @@
+<?php
+
+use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+
+abstract class BaseHeadlessTest extends PHPUnit_Framework_TestCase implements HeadlessInterface, TransactionalInterface {
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+}

--- a/tests/phpunit/CRM/ManageLetterheads/BAO/LetterheadTest.php
+++ b/tests/phpunit/CRM/ManageLetterheads/BAO/LetterheadTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use CRM_ManageLetterheads_Test_Fabricator_Letterhead as LetterheadFabricator;
+
+/**
+ * Letterhead BAO test class
+ *
+ * @group headless
+ */
+class CRM_ManageLetterheads_BAO_LetterheadTest extends BaseHeadlessTest {
+
+  /**
+   * Test that an exception is thrown for invalid available for option value.
+   */
+  public function createThrowsAnExceptionWhenAvailableForValuesAreNotValid() {
+    $this->expectException(new Exception('Please make sure all Available For Options are valid'));
+    LetterheadFabricator::fabricate(['title' => 'Letter Title', 'available_for' => ['blabla', 1]]);
+  }
+
+  /**
+   * Test that the name field is properly populated and is not manipulated.
+   *
+   * @param string $title
+   *   Letterhead title.
+   * @param string $expectedName
+   *   Letterhead name.
+   *
+   * @dataProvider getDataForPopulatingNameField
+   */
+  public function testThatTheNameFieldIsPopulatedAndCanNotBeManipulated($title, $expectedName) {
+    $letterhead = LetterheadFabricator::fabricate(
+      [
+        'title' => $title,
+        'name' => 'Test name',
+        'available_for' => [1],
+      ]
+    );
+
+    $this->assertEquals($expectedName, $letterhead['name']);
+  }
+
+  /**
+   * Tests that available for is saved properly in the letterheadavailability entity.
+   */
+  public function testAvailableForValuesIsSavedCorrectlyForALetterhead() {
+    $availableForExpected = [1, 2];
+    $letterhead = LetterheadFabricator::fabricate(
+      [
+        'title' => 'Test name',
+        'available_for' => $availableForExpected,
+      ]
+    );
+
+    $availability = civicrm_api3('LetterheadAvailability', 'get', ['letterhead_id' => $letterhead['id']]);
+    $availableFor = array_column($availability['values'], 'available_for');
+    $this->assertEquals($availableForExpected, $availableFor);
+  }
+
+  /**
+   * Provides data for testing the name field population.
+   *
+   * @return array
+   *   List of title an expected name.
+   */
+  public function getDataForPopulatingNameField() {
+    return [
+      ['New Title', 'newtitle'],
+      ['Test a new Title', 'testanewtitle'],
+      ['Test_a new-Title', 'test_anew-title'],
+    ];
+  }
+
+}

--- a/tests/phpunit/api/v3/LetterheadTest.php
+++ b/tests/phpunit/api/v3/LetterheadTest.php
@@ -11,11 +11,10 @@ class api_v3_LetterheadTest extends BaseHeadlessTest {
 
   /**
    * Test exception is thrown when available_for not present.
-   *
-   * @expectedException CiviCRM_API3_Exception
-   * @expectedExceptionMessage Mandatory key(s) missing from params array: available_for
    */
   public function testCreateThrowsAnExceptionWhenAvailableForFieldIsNotPresent() {
+    $this->expectException(CiviCRM_API3_Exception::class);
+    $this->expectExceptionMessage('Mandatory key(s) missing from params array: available_for');
     civicrm_api3('Letterhead', 'create', [
       'title' => 'Test title',
       'weight' => 1,
@@ -24,7 +23,7 @@ class api_v3_LetterheadTest extends BaseHeadlessTest {
   }
 
   /**
-   *
+   * Test delete also deletes associated data.
    */
   public function testDeleteAlsoDeletesAssociatedAvailableForFields() {
     $letterhead = LetterheadFabricator::fabricate(
@@ -64,12 +63,11 @@ class api_v3_LetterheadTest extends BaseHeadlessTest {
    * @param  string $sqlOperator
    *   Sql operator.
    *
-   * @expectedException CiviCRM_API3_Exception
-   * @expectedExceptionMessage No SQL operators allowed for available_for
-   *
    * @dataProvider invalidAvailableForLetterheadOptionOperators
    */
   public function testExceptionIsThrownWhenPassingAnInvalidOperatorForAvailableFor($sqlOperator) {
+    $this->expectException(CiviCRM_API3_Exception::class);
+    $this->expectExceptionMessage('No SQL operators allowed for available_for');
     civicrm_api3('Letterhead', 'create', [
       'title' => 'Test title',
       'available_for' => [$sqlOperator => [1]],

--- a/tests/phpunit/api/v3/LetterheadTest.php
+++ b/tests/phpunit/api/v3/LetterheadTest.php
@@ -1,0 +1,98 @@
+<?php
+
+use CRM_ManageLetterheads_Test_Fabricator_Letterhead as LetterheadFabricator;
+
+/**
+ * Letterhead API test class
+ *
+ * @group headless
+ */
+class api_v3_LetterheadTest extends BaseHeadlessTest {
+
+  /**
+   * Test exception is thrown when available_for not present.
+   *
+   * @expectedException CiviCRM_API3_Exception
+   * @expectedExceptionMessage Mandatory key(s) missing from params array: available_for
+   */
+  public function testCreateThrowsAnExceptionWhenAvailableForFieldIsNotPresent() {
+    civicrm_api3('Letterhead', 'create', [
+      'title' => 'Test title',
+      'weight' => 1,
+      'content' => 'Letterhead content',
+    ]);
+  }
+
+  /**
+   *
+   */
+  public function testDeleteAlsoDeletesAssociatedAvailableForFields() {
+    $letterhead = LetterheadFabricator::fabricate(
+      [
+        'title' => 'Test Title',
+        'name' => 'Test name',
+        'available_for' => [1, 2],
+      ]
+    );
+
+    civicrm_api3('Letterhead', 'delete', ['id' => $letterhead['id']]);
+    $availabilityCount = civicrm_api3('LetterheadAvailability', 'getcount', ['letterhead_id' => $letterhead['id']])['result'];
+    $this->assertEquals(0, $availabilityCount);
+  }
+
+  /**
+   * Check that the available for field is returned with Letterhead.get
+   */
+  public function testGetAlsoReturnsAssociatedAvailableForFields() {
+    $availableFor = [1, 2];
+    $letterhead = LetterheadFabricator::fabricate(
+      [
+        'title' => 'Test Title',
+        'name' => 'Test name',
+        'available_for' => $availableFor,
+      ]
+    );
+
+    $result = civicrm_api3('Letterhead', 'get', ['id' => $letterhead['id'], 'sequential' => 1]);
+
+    $this->assertEquals($availableFor, $result['values'][0]['available_for']);
+  }
+
+  /**
+   * Verifies that SQL operators are not allowed for the `available_for` parameter.
+   *
+   * @param  string $sqlOperator
+   *   Sql operator.
+   *
+   * @expectedException CiviCRM_API3_Exception
+   * @expectedExceptionMessage No SQL operators allowed for available_for
+   *
+   * @dataProvider invalidAvailableForLetterheadOptionOperators
+   */
+  public function testExceptionIsThrownWhenPassingAnInvalidOperatorForAvailableFor($sqlOperator) {
+    civicrm_api3('Letterhead', 'create', [
+      'title' => 'Test title',
+      'available_for' => [$sqlOperator => [1]],
+      'weight' => 1,
+      'content' => 'Letterhead content',
+    ]);
+  }
+
+  /**
+   * Returns the invalid operators not allowed when passing the `available for` parameter.
+   *
+   * @return array
+   *   Array of invalid operators.
+   */
+  public function invalidAvailableForLetterheadOptionOperators() {
+    $acceptedSQLOperators = CRM_Core_DAO::acceptedSQLOperators();
+    $invalidSqlOperators = [];
+
+    foreach ($acceptedSQLOperators as $sqlOperator) {
+      $invalidSqlOperators[] = [$sqlOperator];
+    }
+
+    return $invalidSqlOperators;
+  }
+
+}


### PR DESCRIPTION
## Overview
This PR adds PHP unit tests for the work done on this PR: https://github.com/compucorp/uk.co.compucorp.manageletterheads/pull/2

