### PR TITLE
CATL-1794: Edit letterheads

### DIFF
--- a/CRM/ManageLetterheads/Page/LetterheadsListPage.php
+++ b/CRM/ManageLetterheads/Page/LetterheadsListPage.php
@@ -170,6 +170,13 @@ class CRM_ManageLetterheads_Page_LetterheadsListPage extends CRM_Core_Page {
   private function getAllAvailableActions() {
     if (!$this->actions) {
       $this->actions = [
+        CRM_Core_Action::UPDATE => [
+          'class' => 'letterhead-edit crm-popup',
+          'name' => E::ts('Edit'),
+          'title' => E::ts('Edit'),
+          'url' => 'civicrm/letterheads/form',
+          'qs' => 'action=update&id=%%id%%&reset=1',
+        ],
         CRM_Core_Action::ENABLE => [
           'class' => 'letterhead-enable crm-enable-disable',
           'name' => E::ts('Enable'),


### PR DESCRIPTION
## Overview
This PR allows users to edit letterheads.

## How it looks
![gif](https://user-images.githubusercontent.com/1642119/96042493-798bda80-0e3b-11eb-85b9-afe4bb2efb4e.gif)

## Technical Details

We implemented the `UPDATE` form action pointing to the letterhead form. The ID is passed through the action form mask by using the `%%id%%` placeholder.

This implementation follows a similar approach as the following form:
https://github.com/compucorp/civihr/blob/master/uk.co.compucorp.civicrm.hrleaveandabsences/CRM/HRLeaveAndAbsences/Page/AbsenceType.php#L97-L102