### PR TITLE
CATL-1796: Letterheads Menu Link

### DIFF
--- a/CRM/ManageLetterheads/Setup/CreateNavigationItem.php
+++ b/CRM/ManageLetterheads/Setup/CreateNavigationItem.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Setup Class for creating the Letterhead navigation item.
+ */
+class CRM_ManageLetterheads_Setup_CreateNavigationItem {
+
+  /**
+   * Used for running the upgrades.
+   *
+   * @return bool
+   *   TRUE when the upgrader runs successfully.
+   */
+  public function apply() {
+    $this->createManageLetterheadNavigationItem();
+
+    return TRUE;
+  }
+
+  /**
+   * Creates the letterhead navigation item if it doesn't already exist.
+   *
+   * The navigation item is created under Communications.
+   */
+  private function createManageLetterheadNavigationItem() {
+    $communications = civicrm_api3('Navigation', 'getsingle', [
+      'name' => 'Communications',
+      'parent_id' => 'Administer',
+    ]);
+    $letterheads = civicrm_api3('Navigation', 'get', [
+      'name' => 'Letterheads',
+    ]);
+
+    if (empty($letterheads['count'])) {
+      civicrm_api3('Navigation', 'create', [
+        'parent_id' => $communications['id'],
+        'label' => 'Letterheads',
+        'name' => 'Letterheads',
+        'url' => 'civicrm/letterheads/list',
+        'permission' => 'manage letterheads',
+        'is_active' => '1',
+      ]);
+    }
+  }
+
+}

--- a/CRM/ManageLetterheads/Uninstall/DeleteNavigationItem.php
+++ b/CRM/ManageLetterheads/Uninstall/DeleteNavigationItem.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Uninstall Class for deleting the Letterhead navigation item.
+ */
+class CRM_ManageLetterheads_Uninstall_DeleteNavigationItem {
+
+  /**
+   * Used for running the uninstall sequence.
+   *
+   * @return bool
+   *   TRUE when the uninstall sequence runs successfully.
+   */
+  public function apply() {
+    $this->deleteManageLetterheadNavigationItem();
+
+    return TRUE;
+  }
+
+  /**
+   * Deletes the letterhead navigation item if it exists.
+   */
+  private function deleteManageLetterheadNavigationItem() {
+    $letterheads = civicrm_api3('Navigation', 'get', [
+      'sequential' => '1',
+      'name' => 'Letterheads',
+    ]);
+
+    if (!empty($letterheads['count'])) {
+      $navigationItemRecord = CRM_Utils_Array::first($letterheads['values']);
+
+      civicrm_api3('Navigation', 'delete', [
+        'id' => $navigationItemRecord['id'],
+      ]);
+    }
+  }
+
+}

--- a/CRM/ManageLetterheads/Upgrader.php
+++ b/CRM/ManageLetterheads/Upgrader.php
@@ -1,6 +1,7 @@
 <?php
 
 use CRM_ManageLetterheads_Setup_CreateNavigationItem as CreateNavigationItem;
+use CRM_ManageLetterheads_Uninstall_DeleteNavigationItem as DeleteNavigationItem;
 
 /**
  * Collection of upgrade steps.
@@ -27,6 +28,19 @@ class CRM_ManageLetterheads_Upgrader extends CRM_ManageLetterheads_Upgrader_Base
     }
 
     $this->processXMLInstallationFiles();
+  }
+
+  /**
+   * Manage Letterheads uninstall logic.
+   */
+  public function uninstall() {
+    $steps = [
+      new DeleteNavigationItem(),
+    ];
+
+    foreach ($steps as $step) {
+      $step->apply();
+    }
   }
 
   /**

--- a/CRM/ManageLetterheads/Upgrader.php
+++ b/CRM/ManageLetterheads/Upgrader.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_ManageLetterheads_Setup_CreateNavigationItem as CreateNavigationItem;
+
 /**
  * Collection of upgrade steps.
  */
@@ -16,6 +18,14 @@ class CRM_ManageLetterheads_Upgrader extends CRM_ManageLetterheads_Upgrader_Base
    * Custom extension installation logic
    */
   public function install() {
+    $steps = [
+      new CreateNavigationItem(),
+    ];
+
+    foreach ($steps as $step) {
+      $step->apply();
+    }
+
     $this->processXMLInstallationFiles();
   }
 


### PR DESCRIPTION
## Overview
This PR adds the "Letterheads" menu link under Administer > Communications

## How it looks
![gif](https://user-images.githubusercontent.com/1642119/96284264-55e7a200-0fab-11eb-99d4-54c93658a5a3.gif)


## Technical Details

Upgraders and uninstallers have been added to the extension using the pattern we follow in other extensions such as civicase:

https://github.com/compucorp/uk.co.compucorp.civicase/blob/master/CRM/Civicase/Upgrader.php#L71-L83

https://github.com/compucorp/uk.co.compucorp.civicase/blob/master/CRM/Civicase/Upgrader.php#L233-L238
