### PR TITLE
CATL-1894: Fix create message

### DIFF
--- a/CRM/ManageLetterheads/Form/LetterheadForm.php
+++ b/CRM/ManageLetterheads/Form/LetterheadForm.php
@@ -100,8 +100,13 @@ class CRM_ManageLetterheads_Form_LetterheadForm extends CRM_Core_Form {
    * Displays a success message after the letterhead has been created.
    */
   private function addSuccessMessage() {
+    $isAddAction = $this->_action & CRM_Core_Action::ADD;
+    $successMessage = $isAddAction
+      ? E::ts('New letterhead created')
+      : E::ts('Letterhead saved');
+
     CRM_Core_Session::setStatus(
-      E::ts('Letterhead has been saved.'),
+      $successMessage,
       E::ts('Saved'),
       'success'
     );


### PR DESCRIPTION
## Overview
This PR fixes the message displayed after creating letterheads.

## Before
![image-20201021-152740](https://user-images.githubusercontent.com/1642119/96790281-8624ab80-13c4-11eb-9d82-542efaef7a52.png)

## After
![gif](https://user-images.githubusercontent.com/1642119/96790421-c4ba6600-13c4-11eb-9964-00925e86d6dd.gif)

## Technical Details

We updated the `addSuccessMessage` method so it conditionally displays a message when creating a letterhead, and a different one when updating the letterhead, as part of the requirements.
