### PR TITLE
CATL-1795: Fix API Permissions

### DIFF
--- a/CRM/ManageLetterheads/Hook/AlterAPIPermissions/AddLetterheadPermissions.php
+++ b/CRM/ManageLetterheads/Hook/AlterAPIPermissions/AddLetterheadPermissions.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Adds the API permissions for the Letterhead entity.
+ *
+ * All CiviCRM users can access letterheads, but only administrators and
+ * users with the Manage Letterhead permission can create, update, and delete
+ * them.
+ */
+class CRM_ManageLetterheads_Hook_AlterAPIPermissions_AddLetterheadPermissions {
+
+  /**
+   * Handles the hook implementation.
+   *
+   * @param string $entity
+   * @param string $action
+   * @param array $params
+   * @param array $permissions
+   */
+  public function run($entity, $action, &$params, &$permissions) {
+    if (!$this->shouldRun($entity)) {
+      return;
+    }
+
+    $this->addLetterheadPermissions($permissions);
+  }
+
+  /**
+   * Adds the letterhead API permissions.
+   *
+   * @param array $permissions
+   */
+  private function addLetterheadPermissions(&$permissions) {
+    $permissions['letterhead'] = [
+      'get' => ['access CiviCRM'],
+      'default' => ['access CiviCRM', 'manage letterheads'],
+    ];
+  }
+
+  /**
+   * Determines if the hook should run.
+   *
+   * Only adds the permissions when the request belongs to the Letterhead
+   * entity.
+   *
+   * @param string $entity
+   * @return bool
+   */
+  private function shouldRun($entity) {
+    return $entity === 'letterhead';
+  }
+
+}

--- a/manageletterheads.php
+++ b/manageletterheads.php
@@ -1,6 +1,7 @@
 <?php
 
 use CRM_ManageLetterheads_Hook_BuildForm_AddLetterheadDropdown as AddLetterheadDropdown;
+use CRM_ManageLetterheads_Hook_AlterAPIPermissions_AddLetterheadPermissions as AddLetterheadPermissions;
 
 require_once 'manageletterheads.civix.php';
 
@@ -161,5 +162,18 @@ function manageletterheads_civicrm_buildForm($formName, $form) {
 
   foreach ($hooks as $hook) {
     $hook->run($formName, $form);
+  }
+}
+
+/**
+ * Implements hook_civicrm_alterAPIPermissions().
+ */
+function manageletterheads_civicrm_alterAPIPermissions($entity, $action, &$params, &$permissions) {
+  $hooks = [
+    new AddLetterheadPermissions(),
+  ];
+
+  foreach ($hooks as $hook) {
+    $hook->run($entity, $action, $params, $permissions);
   }
 }


### PR DESCRIPTION
## Overview
This PR fixes an issue where users with the "manage letterhead" permission would not be able to disable or delete letterheads.

## Before

### Manage Letterhead user
![gif](https://user-images.githubusercontent.com/1642119/96892835-09431180-1458-11eb-94d8-46e789771ba8.gif)


## After

### Manage Letterhead user
![gif](https://user-images.githubusercontent.com/1642119/96892268-7bffbd00-1457-11eb-91ff-dfca72328be7.gif)


### Civicase user

![gif](https://user-images.githubusercontent.com/1642119/96891747-f54ae000-1456-11eb-9a1a-da55c67aec96.gif)

Can still access the list of letterheads

## Technical Details

We implemented the `civicrm_alterAPIPermissions` hook. When making requests to the letterhead entity, we define that only the `get` action can be executed by all CiviCRM users (`access CiviCRM`), but every other action can be executed by letterhead managers (`manage letterheads`)