### PR TITLE
CPS-376: Fix Bug With Being Unable To Create An Email/Pdf Letter When There Are No LetterHeads

### DIFF
--- a/CRM/ManageLetterheads/Hook/BuildForm/AddLetterheadDropdown.php
+++ b/CRM/ManageLetterheads/Hook/BuildForm/AddLetterheadDropdown.php
@@ -54,6 +54,10 @@ class CRM_ManageLetterheads_Hook_BuildForm_AddLetterheadDropdown {
       'available_for' => $availableForName,
     ]);
 
+    if (empty($availabilityResults['values'])) {
+      return [];
+    }
+
     $letterHeadIds = array_column($availabilityResults['values'], 'letterhead_id');
 
     $letterheadResults = civicrm_api3('Letterhead', 'get', [


### PR DESCRIPTION
## Overview
When the letterheads extension is installed and enabled and there are no letterheads in the system, trying to add an Email/Pdf letter for the contacts on a case will result in an error screen.

<img width="1280" alt="case-latest localcivicrmactivityemailaddactionaddcaseid1atype3reset1cid3snippetjson 2020-11-12 16-01-25" src="https://user-images.githubusercontent.com/6951813/98956490-620a4500-2500-11eb-92c6-3a59c4a4431f.png">

## Before
The issue described above exists.

## After
Issue is because when trying to fetch available letterheads in the `CRM_ManageLetterheads_Hook_BuildForm_AddLetterheadDropdown` hook class, when there are no letterheads, an empty value is used for the IN criteria to fetch the letterhead details thereby triggering a Civicrm API exception. Issue is fixed by returning an empty array when there are no letterheads present.