### PR TITLE
CPS-397: Release 1.0.0-beta.8

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -13,8 +13,8 @@
     <url desc="Documentation">https://github.com/compucorp/uk.co.compucorp.manageletterheads/blob/master/readme.md</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2020-10-26</releaseDate>
-  <version>1.0.0</version>
+  <releaseDate>2020-11-26</releaseDate>
+  <version>1.0.1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.0</ver>


### PR DESCRIPTION
## Release Update - 26th November, 2020
### Bug Fixes
- Fixed Error thrown when attempting to create email or PDF activity on case if there are no letterheads https://github.com/compucorp/uk.co.compucorp.manageletterheads/pull/15

