### PR TITLE
CPS-397: Fix failing Drupal Build For Unit Test Workflow

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -29,7 +29,7 @@ jobs:
         run : amp config:set --mysql_dsn=mysql://root:root@mysql:3306
 
       - name: Build Drupal site
-        run: civibuild create drupal-clean --civi-ver 5.28.3 --web-root $GITHUB_WORKSPACE/site
+        run: civibuild create drupal-clean --civi-ver 5.28.3 --cms-ver 7.74 --web-root $GITHUB_WORKSPACE/site
 
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
## Overview
Recently, creating a Drupal site with civibuild step with the github unit tests workflow was failing and as a result, unit tests were not being ran. 

<img width="1280" alt="RSE-1550 Workflow List new Columns and Filters by deb1990 · Pull Request 644 · compucorpuk co compucorp civicase 2020-11-26 09-22-32" src="https://user-images.githubusercontent.com/6951813/100325718-48b9cc00-2fc9-11eb-946a-0a8c8ed2d741.png">

## Before
The issue described above exists

## After
Because the command to create the drupal site was ran without specifying the drupal version to build the site with i.e `civibuild create drupal-clean --civi-ver 5.28.3 --web-root $GITHUB_WORKSPACE/site`, civibuild will pull from the [Drupal 7.x master](https://github.com/civicrm/civicrm-buildkit/blob/a44e322faf6d3bc21fbc178d44da2fd078e7ae55/app/config/drupal-clean/download.sh#L7) branch.

The Civibuild site creation was [failing](https://github.com/civicrm/civicrm-buildkit/blob/7461255fc26317979c3261e9318d60bbb88bfcd0/src/civibuild.lib.sh#L1051) at the point where a patch for mysql 8 is to be applied for the `mysql/database.inc` file. This was failing because the `mysql/database.inc` file was [updated recently](https://github.com/drupal/drupal/commit/e1892643309aef2eebbbf646ac568795a8849f85#diff-b63d2c77d41d9f57dc94ede9c21dccd6dacfc89e4e977100af9a447b935c422dR365-R371) and therefore the patch was no longer compatible and could not be properly applied.

The solution is to pass a specific drupal version to Civibuild when creating the drupal site to match the same drupal version currently on compuclient, the Drupal `7.74` `mysql/database.inc` file version is still compatible with the mysql 8 patch. 


