### PR TITLE
CATL-2004: Fix letterheads visibility

### DIFF
--- a/CRM/ManageLetterheads/Hook/BuildForm/AddLetterheadDropdown.php
+++ b/CRM/ManageLetterheads/Hook/BuildForm/AddLetterheadDropdown.php
@@ -74,7 +74,9 @@ class CRM_ManageLetterheads_Hook_BuildForm_AddLetterheadDropdown {
    * Adds the given list of letterheads to a configuration variable.
    *
    * This configuration variable can be accessed by the front-end to build
-   * the dropdown for the letterheads.
+   * the dropdown for the letterheads. The letterheads are provided as a JSON
+   * string to avoid CiviCRM from extending the object instead of replacing
+   * it.
    *
    * The script to build this dropdown is also appended.
    *
@@ -86,7 +88,7 @@ class CRM_ManageLetterheads_Hook_BuildForm_AddLetterheadDropdown {
       ->addScriptFile('uk.co.compucorp.manageletterheads', 'js/letterheads-dropdown.js')
       ->addSetting([
         'manageletterheads' => [
-          'letterhead_options' => $letterheads,
+          'letterhead_options' => json_encode($letterheads),
         ],
       ]);
   }

--- a/js/letterheads-dropdown.js
+++ b/js/letterheads-dropdown.js
@@ -1,6 +1,7 @@
-(($, _, letterheadOptions, ts, crmWysiwyg) => {
+(($, _, ManageLetterheads, ts, crmWysiwyg) => {
   var $htmlMessageEditor, $letterheadDropdown, $templateRow, $templateDropdown,
     isEmailForm;
+  var letterheadOptions = JSON.parse(ManageLetterheads.letterhead_options);
 
   $(document).ready(function () {
     initDomElementReferences();
@@ -171,5 +172,5 @@
    * @property {string} [labelClass] A class that will be applied directly to the label element.
    * @property {string} [labelTdClass] A class that will be applied to the label's parent TD element.
    */
-})(CRM.$, CRM._, CRM.manageletterheads.letterhead_options,
+})(CRM.$, CRM._, CRM.manageletterheads,
   CRM.ts('uk.co.compucorp.manageletterheads'), CRM.wysiwyg);

--- a/tests/js/globals/letterhead-options.js
+++ b/tests/js/globals/letterhead-options.js
@@ -1,6 +1,6 @@
 (() => {
   CRM.manageletterheads = CRM.manageletterheads || {};
-  CRM.manageletterheads.letterhead_options = [
+  CRM.manageletterheads.letterhead_options = JSON.stringify([
     {
       id: '1',
       title: 'Letterhead (English)',
@@ -28,5 +28,5 @@
       is_active: '1',
       weight: '3'
     }
-  ];
+  ]);
 })();

--- a/tests/phpunit/CRM/ManageLetterheads/Hook/AddLetterheadDropdownTest.php
+++ b/tests/phpunit/CRM/ManageLetterheads/Hook/AddLetterheadDropdownTest.php
@@ -1,0 +1,170 @@
+<?php
+
+use CRM_ManageLetterheads_Test_Fabricator_Letterhead as LetterheadFabricator;
+use CRM_ManageLetterheads_Hook_BuildForm_AddLetterheadDropdown as AddLetterheadDropdown;
+
+/**
+ * Add Letterhead Dropdown hook test.
+ *
+ * @group headless
+ */
+class CRM_ManageLetterheads_Hook_AddLetterheadDropdownTest extends BaseHeadlessTest {
+
+  /**
+   * Tests that email letterheads are added to the CRM config when sending emails.
+   */
+  public function testEmailFormsWhenThereAreEmailLetterheads () {
+    $this->fabricateEmailLetterhead('Email Letterhead');
+    $this->fabricatePdfLetterhead('PDF Letterhead');
+    $this->fabricateGenericLetterhead('Generic Letterhead');
+
+    $hook = new AddLetterheadDropdown();
+    $hook->run(
+      'CRM_Contact_Form_Task_Email',
+      new CRM_Contact_Form_Task_Email()
+    );
+
+    $letterheadOptions = $this->getLetterheadOptions();
+
+    $this->assertCount(2, $letterheadOptions);
+    $this->assertEquals('Email Letterhead', $letterheadOptions[0]->title);
+    $this->assertContains('Generic Letterhead', $letterheadOptions[1]->title);
+  }
+
+  /**
+   * Tests that no letterheads are added when sending an email and there are no email letterheads.
+   */
+  public function testEmailFormsWhenThereAreNoEmailLetterheads () {
+    $this->fabricatePdfLetterhead('PDF Letterhead');
+
+    $hook = new AddLetterheadDropdown();
+    $hook->run(
+      'CRM_Contact_Form_Task_Email',
+      new CRM_Contact_Form_Task_Email()
+    );
+
+    $letterheadOptions = $this->getLetterheadOptions();
+
+    $this->assertCount(0, $letterheadOptions);
+  }
+
+  /**
+   * Tests that PDF letterheads are added to the CRM config when creating PDF letters.
+   */
+  public function testPdfFormsWhenThereArePdfLetterheads () {
+    $this->fabricateEmailLetterhead('Email Letterhead');
+    $this->fabricatePdfLetterhead('PDF Letterhead');
+    $this->fabricateGenericLetterhead('Generic Letterhead');
+
+    $hook = new AddLetterheadDropdown();
+    $hook->run(
+      'CRM_Contact_Form_Task_PDF',
+      new CRM_Contact_Form_Task_PDF()
+    );
+
+    $letterheadOptions = $this->getLetterheadOptions();
+
+    $this->assertCount(2, $letterheadOptions);
+    $this->assertEquals('PDF Letterhead', $letterheadOptions[0]->title);
+    $this->assertContains('Generic Letterhead', $letterheadOptions[1]->title);
+  }
+
+  /**
+   * Tests that no letterheads are added when creating a PDF letter and there are no PDF letterheads.
+   */
+  public function testPdfFormsWhenThereAreNoPdfLetterheads () {
+    $this->fabricateEmailLetterhead('Email Letterhead');
+
+    $hook = new AddLetterheadDropdown();
+    $hook->run(
+      'CRM_Contact_Form_Task_PDF',
+      new CRM_Contact_Form_Task_PDF()
+    );
+
+    $letterheadOptions = $this->getLetterheadOptions();
+
+    $this->assertCount(0, $letterheadOptions);
+  }
+
+  /**
+   * Tests that no letterheads are added when using non Email or PDF Letter forms.
+   */
+  public function testNoLetterheadsWhenUsingNonEmailOrPdfForms () {
+    $this->fabricateEmailLetterhead('Email Letterhead');
+    $this->fabricatePdfLetterhead('PDF Letterhead');
+    $this->fabricateGenericLetterhead('Generic Letterhead');
+
+    $hook = new AddLetterheadDropdown();
+    $hook->run(
+      'CRM_Contact_Form_Contact',
+      new CRM_Contact_Form_Contact()
+    );
+
+    $letterheadOptions = $this->getLetterheadOptions();
+
+    $this->assertCount(0, $letterheadOptions);
+  }
+
+  /**
+   * Fabricates an email letterhead.
+   *
+   * @param string $title
+   *   The letterhead title.
+   * @return array
+   *   The letterhead as returned by the API.
+   */
+  private function fabricateEmailLetterhead($title) {
+    return LetterheadFabricator::fabricate([
+      'title' => $title,
+      'available_for' => [1],
+    ]);
+  }
+
+  /**
+   * Fabricates a PDF letterhead.
+   *
+   * @param string $title
+   *   The letterhead title.
+   * @return array
+   *   The letterhead as returned by the API.
+   */
+  private function fabricatePdfLetterhead($title) {
+    return LetterheadFabricator::fabricate([
+      'title' => $title,
+      'available_for' => [2],
+    ]);
+  }
+
+  /**
+   * Fabricates a letterhead that can be used for emails and PDF letters.
+   *
+   * @param string $title
+   *   The letterhead title.
+   * @return array
+   *   The letterhead as returned by the API.
+   */
+  private function fabricateGenericLetterhead($title) {
+    return LetterheadFabricator::fabricate([
+      'title' => $title,
+      'available_for' => [1, 2],
+    ]);
+  }
+
+  /**
+   * Returns the letterhead options stored in the CRM settings.
+   *
+   * The options are decoded since they are stored as a JSON string. If no
+   * options are stored, it will return an empty array.
+   *
+   * @return array
+   *   An array of letterhead objects.
+   */
+  private function getLetterheadOptions() {
+    $crmSettings = CRM_Core_Resources::singleton()->getSettings();
+
+    return isset($crmSettings['manageletterheads'])
+      ? json_decode($crmSettings['manageletterheads']['letterhead_options'])
+      : [];
+  }
+
+}

--- a/tests/phpunit/CRM/ManageLetterheads/Hook/BuildForm/AddLetterheadDropdownTest.php
+++ b/tests/phpunit/CRM/ManageLetterheads/Hook/BuildForm/AddLetterheadDropdownTest.php
@@ -8,7 +8,7 @@ use CRM_ManageLetterheads_Hook_BuildForm_AddLetterheadDropdown as AddLetterheadD
  *
  * @group headless
  */
-class CRM_ManageLetterheads_Hook_AddLetterheadDropdownTest extends BaseHeadlessTest {
+class CRM_ManageLetterheads_Hook_BuildForm_AddLetterheadDropdownTest extends BaseHeadlessTest {
 
   /**
    * Tests that email letterheads are added to the CRM config when sending emails.


### PR DESCRIPTION
## Overview
This PR fixes an issue with letterheads where PDF or Email letterheads would be visible in the wrong forms.

## Before
![pr](https://user-images.githubusercontent.com/1642119/102159466-fba77800-3e59-11eb-9ece-309cbf92850e.gif)

## After
![pr](https://user-images.githubusercontent.com/1642119/102156831-c8161f00-3e54-11eb-8220-4f48b1a4c478.gif)

## Technical Details

The issue happens because when settings through `CRM_Core_Resources`, the `addSetting` method will try to merge the new options with any previous options. This happens for objects and array. To fix the issue we pass the letterhead options as a JSON string which guarantees that the options will be completely replaced when using different forms.

We also added some missings tests for the letterhead dropdown options hook.