### PR TITLE
MAE-847: PHP8+CiviCRM 5.51.3 update

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -6,7 +6,7 @@ jobs:
   run-unit-tests:
 
     runs-on: ubuntu-latest
-    container: compucorp/civicrm-buildkit:1.1.1-php7.2-chrome
+    container: compucorp/civicrm-buildkit:1.3.0-php8.0-chrome
 
     env:
       CIVICRM_EXTENSIONS_DIR: site/web/sites/all/modules/civicrm/tools/extensions
@@ -29,7 +29,15 @@ jobs:
         run : amp config:set --mysql_dsn=mysql://root:root@mysql:3306
 
       - name: Build Drupal site
-        run: civibuild create drupal-clean --civi-ver 5.51.3 --cms-ver 7.85 --web-root $GITHUB_WORKSPACE/site
+        run: civibuild create drupal-clean --civi-ver 5.51.3 --cms-ver 7.79 --web-root $GITHUB_WORKSPACE/site
+
+      - uses: compucorp/apply-patch@1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          repo: compucorp/civicrm-core
+          version: 5.51.3
+          path: site/web/sites/all/modules/civicrm
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -6,7 +6,7 @@ jobs:
   run-unit-tests:
 
     runs-on: ubuntu-latest
-    container: compucorp/civicrm-buildkit:1.0.0-chrome
+    container: compucorp/civicrm-buildkit:1.1.1-php7.2-chrome
 
     env:
       CIVICRM_EXTENSIONS_DIR: site/web/sites/all/modules/civicrm/tools/extensions
@@ -29,7 +29,7 @@ jobs:
         run : amp config:set --mysql_dsn=mysql://root:root@mysql:3306
 
       - name: Build Drupal site
-        run: civibuild create drupal-clean --civi-ver 5.28.3 --cms-ver 7.74 --web-root $GITHUB_WORKSPACE/site
+        run: civibuild create drupal-clean --civi-ver 5.51.3 --cms-ver 7.85 --web-root $GITHUB_WORKSPACE/site
 
       - uses: actions/checkout@v2
         with:

--- a/CRM/ManageLetterheads/Page/LetterheadsListPage.php
+++ b/CRM/ManageLetterheads/Page/LetterheadsListPage.php
@@ -110,7 +110,7 @@ class CRM_ManageLetterheads_Page_LetterheadsListPage extends CRM_Core_Page {
       $letterhead['available_for']
     );
 
-    $letterhead['available_for_text'] = implode($availableForLabels, ', ');
+    $letterhead['available_for_text'] = implode(', ', $availableForLabels);
     $letterhead['actions'] = $this->getLetterheadActions($letterhead);
     $letterhead['is_active_text'] = $letterhead['is_active'] === '1'
       ? E::ts('Yes')

--- a/tests/js/karma.conf.js
+++ b/tests/js/karma.conf.js
@@ -28,7 +28,7 @@ module.exports = function (config) {
       'bower_components/ckeditor/lang/en.js',
       'bower_components/ckeditor/styles.js',
       'js/wysiwyg/crm.wysiwyg.js',
-      'js/wysiwyg/crm.ckeditor.js',
+      'ext/ckeditor4/js/crm.ckeditor.js',
       { pattern: 'bower_components/ckeditor/**/*.css' },
 
       // Source Files

--- a/tests/phpunit/api/v3/LetterheadTest.php
+++ b/tests/phpunit/api/v3/LetterheadTest.php
@@ -35,7 +35,7 @@ class api_v3_LetterheadTest extends BaseHeadlessTest {
     );
 
     civicrm_api3('Letterhead', 'delete', ['id' => $letterhead['id']]);
-    $availabilityCount = civicrm_api3('LetterheadAvailability', 'getcount', ['letterhead_id' => $letterhead['id']])['result'];
+    $availabilityCount = civicrm_api3('LetterheadAvailability', 'getcount', ['letterhead_id' => $letterhead['id']]);
     $this->assertEquals(0, $availabilityCount);
   }
 


### PR DESCRIPTION
## Overview

When Checking for PHP 8.0 compatibility, the following error was reported.

```
Passing the $glue and $pieces parameters in reverse order to implode has been deprecated since PHP 7.4; $glue should be the first parameter and $pieces the second.
```

The error was resolved by reversing the order of parameters to the implode function.

Also, the test failed because the test setup pointed to the wrong `ckeditor.js` file path since the `ckeditor.js` has been moved outside of the CiviCRM core in the latest vesion to an extension. changed the referenced path to the ext path.