### PR TITLE
NEUSPRT-406: Add Letterhead Field To Case Email Form

### DIFF
--- a/CRM/ManageLetterheads/Hook/BuildForm/AddLetterheadDropdown.php
+++ b/CRM/ManageLetterheads/Hook/BuildForm/AddLetterheadDropdown.php
@@ -28,7 +28,7 @@ class CRM_ManageLetterheads_Hook_BuildForm_AddLetterheadDropdown {
    */
   public function run ($formName, $form) {
     $this->isPdfLetterForm = get_class($form) === CRM_Contact_Form_Task_PDF::class;
-    $this->isEmailForm = get_class($form) === CRM_Contact_Form_Task_Email::class;
+    $this->isEmailForm = in_array(get_class($form), [CRM_Contact_Form_Task_Email::class, CRM_Case_Form_Task_Email::class]);
 
     if (!$this->shouldRun()) {
       return;


### PR DESCRIPTION
## Overview
Previously the letterhead field was only available for contact pdf and contact email form. This pr adds the field to case email form as well.

## Before
<img width="1615" alt="Screenshot 2024-12-03 at 2 50 24 PM" src="https://github.com/user-attachments/assets/4485ef8b-ee84-48a2-834a-5b7fb3d58072" />


## After
<img width="1615" alt="Screenshot 2024-12-03 at 2 50 06 PM" src="https://github.com/user-attachments/assets/0ebfd5e3-0094-4510-814c-544752a5c169" />

## Technical Details
In [this](https://github.com/compucorp/uk.co.compucorp.civicase/pull/870) pr for add new email option on case details page we changed the form from contact email to case email form but we did not add the letterhead field to this case email form.

