### PR TITLE
CIVIMM-293: Fix permission label

### DIFF
--- a/manageletterheads.php
+++ b/manageletterheads.php
@@ -43,8 +43,8 @@ function manageletterheads_civicrm_enable() {
  */
 function manageletterheads_civicrm_permission(&$permissions) {
   $permissions['manage letterheads'] = [
-    ts('CiviCRM: manage letterheads'),
-    ts('Allows managing of a list of letterheads that can be selected by users when creating emails and PDF letters'),
+    'label' => ts('CiviCRM: manage letterheads'),
+    'description' => ts('Allows managing of a list of letterheads that can be selected by users when creating emails and PDF letters'),
   ];
 }
 


### PR DESCRIPTION
## Overview

CiviCRM 5.0+ uses a newer format for declaring permissions. As of Civi 5.71, the old format is deprecated.